### PR TITLE
feat: add full-review-gate command with worktree isolation and PR shipping

### DIFF
--- a/.claude/commands/full-review-gate.md
+++ b/.claude/commands/full-review-gate.md
@@ -1,0 +1,279 @@
+Perform a comprehensive repository code review in an isolated worktree. Fix P0/P1 findings and ship them as a PR targeting the current branch.
+
+## Instructions
+
+Follow these steps precisely. Do not skip any pass or omit severity classification.
+
+---
+
+## Part 0: Setup
+
+### Step 1: Record State and Confirm Scope
+
+Record the current branch:
+
+```bash
+ORIGINAL_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+```
+
+Ask the user which scope to use:
+
+- **Full-repository scope**: use for complete reviews or release readiness checks.
+- **Diff-focused scope**: use only when the user explicitly asks for a PR or diff review. Still inspect adjacent components likely to regress.
+
+### Step 2: Create Worktree
+
+First, clean any stale worktrees from prior interrupted runs:
+
+```bash
+git worktree list
+```
+
+For any entries with paths containing `.claude/worktrees/review-gate-`, remove them:
+
+```bash
+git worktree remove --force <stale-path>
+```
+
+Generate a branch slug from `ORIGINAL_BRANCH` (replace `/` and special characters with `-`, truncate to 30 characters). Create the worktree:
+
+```bash
+mkdir -p .claude/worktrees
+git worktree add .claude/worktrees/review-gate-<branch-slug> HEAD
+```
+
+Save the full path as `WORKTREE_DIR`. If creation fails, report the error and stop.
+
+---
+
+## Part 1: Review (in worktree)
+
+### Step 3: Run Baseline Checks
+
+Run the automated baseline from within the worktree:
+
+```bash
+cd <WORKTREE_DIR> && bash scripts/run-review-gate.sh
+```
+
+If optional tools are missing (shellcheck, gitleaks, pip-audit, govulncheck), continue and note the coverage gaps for the final report.
+
+### Step 4: Perform Manual Passes
+
+Review the codebase from `WORKTREE_DIR` using the criteria below, in this order:
+
+1. **Bug and Regression Pass**
+   - Validate correctness for happy path, edge cases, and error handling.
+   - Detect behavioral regressions in touched and adjacent modules.
+   - Verify tests cover business-critical paths and failure scenarios.
+   - Flag missing assertions, brittle tests, or untested branches.
+
+2. **Security Pass**
+   - Verify input validation and output encoding at trust boundaries.
+   - Verify authorization checks are enforced server-side.
+   - Review secret handling, credential storage, and log redaction.
+   - Detect injection vectors, unsafe deserialization, and path traversal risks.
+   - Verify dependency vulnerabilities and insecure defaults.
+
+3. **PII and Privacy Pass**
+   - Identify collection and storage of direct identifiers.
+   - Verify logs do not store raw PII, tokens, or credentials.
+   - Verify test fixtures use synthetic data rather than real user data.
+   - Check retention and data-flow behavior against least-data principles.
+
+4. **Dependency Adoption and Version-Risk Pass**
+   - Prefer stable and generally adopted major versions over niche or abandoned packages.
+   - Verify active maintenance and recent releases.
+   - Avoid pre-release versions unless explicitly required.
+   - Check known CVEs and changelog notes for breaking security changes.
+
+All file reads during review must use `<WORKTREE_DIR>/<path>`.
+
+---
+
+## Part 2: Report
+
+### Step 5: Report Findings
+
+Use the severity rubric:
+
+- **P0**: Critical exploit or data-loss risk. Block release immediately.
+- **P1**: High-impact bug or security/privacy risk likely in production. Block release until fixed.
+- **P2**: Medium risk with bounded impact or mitigations. Fix before next release unless explicitly accepted.
+- **P3**: Low risk, quality issue, or improvement. Track and prioritize normally.
+
+List findings first, ordered P0 to P3. For each finding include:
+
+1. Severity
+2. File and line reference
+3. Exploit or failure scenario
+4. Impact
+5. Exact remediation
+6. Required tests
+
+Then include:
+
+1. Release blocker list
+2. Residual risk list
+3. Coverage gaps caused by missing tools
+
+Use this response structure:
+
+```text
+Findings (P0-P3):
+- [Px] Title
+  - File: <path>:<line>
+  - Scenario:
+  - Impact:
+  - Fix:
+  - Tests:
+
+Release blockers:
+- ...
+
+Residual risk:
+- ...
+
+Verification rerun:
+- verify.sh: pass/fail
+- run-tests.sh: pass/fail
+- security/PII scans: pass/fail/partial
+```
+
+Save the findings internally for use in the PR body.
+
+### Step 6: Early Exit Check
+
+If there are **zero P0 or P1 findings**:
+
+1. Report "No release blockers found. No PR needed."
+2. Skip directly to Step 10 (cleanup).
+
+---
+
+## Part 3: Fix and Ship
+
+### Step 7: Fix P0/P1 Issues in Worktree
+
+For each P0 and P1 finding:
+
+1. Read the affected file from `<WORKTREE_DIR>/<path>`.
+2. Apply the fix in the worktree.
+3. Note what was changed.
+
+After all fixes, run the regeneration and validation cycle:
+
+- If any files under `core/`, `generator/templates/`, `generator/generate.py`, or `platforms/*/platform.json` were modified:
+  ```bash
+  cd <WORKTREE_DIR> && python3 generator/generate.py --all
+  ```
+
+- Run validation from the worktree:
+  ```bash
+  cd <WORKTREE_DIR> && python3 generator/validate.py
+  cd <WORKTREE_DIR> && bash scripts/run-tests.sh
+  ```
+
+- If validation fails, attempt to fix (up to 2 retries). If still failing, report and stop.
+
+Re-run baseline checks to confirm blockers are closed:
+
+```bash
+cd <WORKTREE_DIR> && bash scripts/run-review-gate.sh
+```
+
+### Step 8: Commit and Push from Worktree
+
+1. Create a new branch in the worktree:
+   ```bash
+   git -C <WORKTREE_DIR> checkout -b fix/review-gate-<branch-slug>
+   ```
+   If the branch name already exists, append `-2` (or `-3`, etc.).
+
+2. Stage all modified files:
+   ```bash
+   git -C <WORKTREE_DIR> add -A
+   ```
+
+3. Un-stage any sensitive files (`.env*`, `credentials.json`, `*.pem`, `*.key`).
+
+4. Generate a commit message with `fix:` prefix summarizing the findings. Commit using heredoc:
+   ```bash
+   git -C <WORKTREE_DIR> commit -m "$(cat <<'EOF'
+   fix: resolve P0/P1 review gate findings
+   EOF
+   )"
+   ```
+   Do NOT use `--no-verify`. If the pre-commit hook fails, fix and retry (up to 2 times).
+
+5. Push the fix branch:
+   ```bash
+   git -C <WORKTREE_DIR> push -u origin fix/review-gate-<branch-slug>
+   ```
+
+Save the branch name as `FIX_BRANCH`.
+
+### Step 9: Create PR
+
+Create a PR targeting the original branch:
+
+```bash
+gh pr create --base <ORIGINAL_BRANCH> --head <FIX_BRANCH> \
+  --title "fix: review gate P0/P1 remediations for <ORIGINAL_BRANCH>" \
+  --body "$(cat <<'EOF'
+## Review Gate Findings
+
+This PR addresses P0 and P1 findings from a full review gate run.
+
+### Fixed (P0/P1)
+
+<for each fixed finding:>
+- **[Px]** <title> — <file>:<line>
+  - <one-line fix description>
+
+### Remaining (P2/P3)
+
+<for each unfixed finding:>
+- **[Px]** <title> — <file>:<line>
+  - <one-line description>
+
+## Verification
+
+- `run-review-gate.sh`: <pass/fail after fixes>
+- `run-tests.sh`: <pass/fail>
+- `validate.py`: <pass/fail>
+- Coverage gaps: <list any missing tools>
+
+## Test Plan
+
+- [ ] Verify P0/P1 fixes do not introduce regressions
+- [ ] Run `bash scripts/run-review-gate.sh` on the merged result
+- [ ] Confirm P2/P3 items are tracked for follow-up
+EOF
+)"
+```
+
+Save the PR URL.
+
+---
+
+## Part 4: Cleanup
+
+### Step 10: Cleanup and Report
+
+Remove the worktree:
+
+```bash
+git worktree remove <WORKTREE_DIR> --force
+rmdir .claude/worktrees/ 2>/dev/null
+```
+
+Report the result:
+
+- If no P0/P1 findings (early exit): "Review gate passed. No release blockers found."
+- If P0/P1 findings were fixed:
+  - PR URL
+  - Fix branch name and target branch
+  - Number of P0/P1 findings fixed
+  - Number of P2/P3 findings remaining
+  - Reminder: "Your `<ORIGINAL_BRANCH>` branch is unchanged. Merge the PR to incorporate fixes."

--- a/.claude/commands/pr-fix.md
+++ b/.claude/commands/pr-fix.md
@@ -1,4 +1,4 @@
-Fetch inline review comments from a GitHub PR, group by issue type, apply fixes, and push. Supports a `watch` submode for PR babysitting with `/loop`.
+Fetch inline review comments from a GitHub PR, group by issue type, apply fixes, and push — all in an isolated git worktree. Supports `watch` submode for PR babysitting and `all` submode to fix every open PR with review comments.
 
 ## Instructions
 
@@ -6,12 +6,14 @@ Follow these steps precisely. Do NOT add a Co-Authored-By line to commits.
 
 ### Argument Parsing
 
-Parse `$ARGUMENTS` for one of two modes:
+Parse `$ARGUMENTS` for one of three modes:
 
 - **Fix mode** (default): `$ARGUMENTS` is a PR number (e.g., `3`) or empty.
 - **Watch mode**: `$ARGUMENTS` starts with `watch` followed by a PR number (e.g., `watch 3`).
+- **All mode**: `$ARGUMENTS` starts with `all`, optionally followed by `--dry-run` and/or a number limit (e.g., `all`, `all --dry-run`, `all 3`, `all --dry-run 3`).
 
 If watch mode is detected, skip to the **Watch Mode** section below.
+If all mode is detected, skip to the **All Mode** section below.
 
 For fix mode, extract the PR number from `$ARGUMENTS`. If empty, try auto-detection: `gh pr view --json number -q .number 2>/dev/null`. If auto-detection fails, ask the user "Which PR number should I fix?" and wait for their response.
 
@@ -23,26 +25,30 @@ For fix mode, extract the PR number from `$ARGUMENTS`. If empty, try auto-detect
 
 1. **GitHub CLI available**: Run `gh --version`. If unavailable, tell the user "GitHub CLI (gh) is required. Install with: brew install gh" and stop.
 2. **PR exists and is open**: Run `gh pr view <PR_NUMBER> --json number,state,headRefName,baseRefName,title`. If the PR does not exist or is not open, report the error and stop. Save `headRefName` as `PR_BRANCH` and `title` as `PR_TITLE`.
-3. **Working tree is clean**: Run `git status`. If there are uncommitted changes, tell the user "Working tree is not clean. Commit or stash changes first." and stop.
+3. **Extract owner/repo**: Run `gh repo view --json owner,name -q '.owner.login + "/" + .name'`. Save as `OWNER_REPO`.
+4. **Clean stale worktrees**: Run `git worktree list`. For any entries with paths containing `.claude/worktrees/pr-fix-`, remove them with `git worktree remove --force <path>`. This handles leftovers from interrupted prior runs.
 
-### Step 2: Switch to the PR branch
+### Step 2: Create worktree
 
-1. Run `git rev-parse --abbrev-ref HEAD` and save as `ORIGINAL_BRANCH`.
-2. If `ORIGINAL_BRANCH` != `PR_BRANCH`, run `git checkout <PR_BRANCH>`. If the branch does not exist locally, run `git checkout -t origin/<PR_BRANCH>`.
-3. Run `git pull --ff-only` to ensure the branch is up to date.
+1. Fetch the latest remote state: `git fetch origin <PR_BRANCH>`.
+2. Create an isolated worktree:
+   ```
+   git worktree add .claude/worktrees/pr-fix-<PR_NUMBER> origin/<PR_BRANCH>
+   ```
+3. If worktree creation fails (e.g., branch already checked out), report the error and stop.
+
+Save `.claude/worktrees/pr-fix-<PR_NUMBER>` as `WORKTREE_DIR`.
 
 ### Step 3: Fetch review comments
 
-Extract owner and repo: `gh repo view --json owner,name -q '.owner.login + "/" + .name'`.
-
 Fetch all inline review comments:
 ```
-gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments --paginate
+gh api repos/{OWNER_REPO}/pulls/<PR_NUMBER>/comments --paginate
 ```
 
 For each comment, extract: `id`, `path`, `line`, `original_line`, `body`, `diff_hunk`.
 
-If no comments are found, report "No review comments on PR #<PR_NUMBER>" and skip to Step 8.
+If no comments are found, report "No review comments on PR #<PR_NUMBER>" and skip to Step 9.
 
 ### Step 4: Group and deduplicate comments
 
@@ -73,27 +79,27 @@ Issue 2/M: <issue title>
 For each unique issue group (maximum 10 groups — if more, warn and stop):
 
 1. **Present**: Show the full comment body and all affected file paths with their diff hunks.
-2. **Read**: Read each affected file to understand the current code.
-3. **Fix**: Apply the code change that addresses the review comment. If the comment includes a code suggestion block, use it as a starting point but verify correctness.
+2. **Read**: Read each affected file from the worktree path (`<WORKTREE_DIR>/<path>`) to understand the current code.
+3. **Fix**: Apply the code change that addresses the review comment. If the comment includes a code suggestion block, use it as a starting point but verify correctness. All file edits must target files inside `WORKTREE_DIR`.
 4. **Report**: Tell the user what was changed in each file.
 
 After all groups are processed, proceed to Step 6.
 
 ### Step 6: Regenerate and validate
 
-Check the list of modified files.
+Check the list of modified files (relative to the worktree).
 
 **If any files under `core/`, `generator/templates/`, `generator/generate.py`, or `platforms/*/platform.json` were modified:**
-- Run `python3 generator/generate.py --all`
+- Run `python3 generator/generate.py --all` from `WORKTREE_DIR`
 - Stage regenerated files
 
 **If any checksummed files were modified** (`skills/specops/SKILL.md`, `schema.json`, `platforms/claude/SKILL.md`, `platforms/claude/platform.json`, `platforms/cursor/specops.mdc`, `platforms/cursor/platform.json`, `platforms/codex/SKILL.md`, `platforms/codex/platform.json`, `platforms/copilot/specops.instructions.md`, `platforms/copilot/platform.json`, `core/workflow.md`, `core/safety.md`, `hooks/pre-commit`, `hooks/pre-push`, `scripts/install-hooks.sh`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`):
-- Regenerate checksums:
+- Regenerate checksums from `WORKTREE_DIR`:
   ```
-  shasum -a 256 skills/specops/SKILL.md schema.json platforms/claude/SKILL.md platforms/claude/platform.json platforms/cursor/specops.mdc platforms/cursor/platform.json platforms/codex/SKILL.md platforms/codex/platform.json platforms/copilot/specops.instructions.md platforms/copilot/platform.json core/workflow.md core/safety.md hooks/pre-commit hooks/pre-push scripts/install-hooks.sh .claude-plugin/plugin.json .claude-plugin/marketplace.json > CHECKSUMS.sha256
+  cd <WORKTREE_DIR> && shasum -a 256 skills/specops/SKILL.md schema.json platforms/claude/SKILL.md platforms/claude/platform.json platforms/cursor/specops.mdc platforms/cursor/platform.json platforms/codex/SKILL.md platforms/codex/platform.json platforms/copilot/specops.instructions.md platforms/copilot/platform.json core/workflow.md core/safety.md hooks/pre-commit hooks/pre-push scripts/install-hooks.sh .claude-plugin/plugin.json .claude-plugin/marketplace.json > CHECKSUMS.sha256
   ```
 
-Run validation:
+Run validation from `WORKTREE_DIR`:
 1. `python3 generator/validate.py`
 2. `shasum -a 256 -c CHECKSUMS.sha256`
 3. `bash scripts/run-tests.sh`
@@ -102,32 +108,37 @@ If any validation fails, attempt to fix (up to 2 retries). If still failing, sto
 
 ### Step 7: Commit and push
 
-1. Stage all modified files: `git add -A`
+1. Stage all modified files: `git -C <WORKTREE_DIR> add -A`
 2. Un-stage sensitive files (`.env*`, `credentials.json`, `*.pem`, `*.key`, SSH keys) if any.
 3. Generate a commit message with `fix:` prefix summarizing the review fixes.
 4. Commit using heredoc:
    ```
-   git commit -m "$(cat <<'EOF'
+   git -C <WORKTREE_DIR> commit -m "$(cat <<'EOF'
    fix: <generated message>
    EOF
    )"
    ```
 5. Do NOT use `--no-verify`. If pre-commit hook fails, fix and retry (up to 2 times).
-6. Push: `git push`. Do NOT use `--no-verify`.
+6. Push: `git -C <WORKTREE_DIR> push`. Do NOT use `--no-verify`.
 
 ### Step 8: Reply to PR comments
 
 For each issue group that was fixed, reply to ONE comment in the group (the first one) using:
 
 ```
-gh api repos/{owner}/{repo}/pulls/comments/<comment_id>/replies -f body="Fixed in <short-sha>."
+gh api repos/{OWNER_REPO}/pulls/comments/<comment_id>/replies -f body="Fixed in <short-sha>."
 ```
 
 This avoids spamming every duplicate comment with a reply.
 
-### Step 9: Return to original branch
+### Step 9: Cleanup worktree
 
-If `ORIGINAL_BRANCH` != `PR_BRANCH`, run `git checkout <ORIGINAL_BRANCH>`.
+Remove the worktree:
+```
+git worktree remove <WORKTREE_DIR> --force
+```
+
+If the `.claude/worktrees/` directory is empty after cleanup, remove it: `rmdir .claude/worktrees/ 2>/dev/null`.
 
 ### Step 10: Confirm
 
@@ -136,7 +147,6 @@ Report the result:
 - Files modified
 - Commit hash and message
 - PR URL
-- Branch returned to
 - Suggest: "Run `/loop 15m /pr-fix watch <PR_NUMBER>` to babysit this PR."
 
 ---
@@ -232,3 +242,181 @@ Write updated state to `.claude/.pr-fix-state-<PR_NUMBER>.json`:
 - Auto-fixes are conservative: only apply when the fix is unambiguous (code suggestion blocks targeting a single clear change).
 - Never auto-fix changes to security-sensitive files (`core/safety.md`, `core/workflow.md`, `generator/generate.py`, etc.) — always notify the user.
 - The state file is gitignored (`.claude/` is typically in `.gitignore`).
+
+---
+
+## All Mode
+
+All mode discovers every open PR with review comments and fixes them all, each in its own isolated git worktree.
+
+### Argument Parsing (All Mode)
+
+Parse everything after `all` in `$ARGUMENTS`:
+
+- `--dry-run` or `dry-run`: Preview mode — discover and display what would be fixed without applying changes.
+- A number (e.g., `3`): Override the maximum PR limit (default is 5).
+- Both can be combined: `all --dry-run 3` or `all 3 --dry-run`.
+
+### Step A1: Pre-flight checks
+
+1. **GitHub CLI available**: Run `gh --version`. If unavailable, tell the user "GitHub CLI (gh) is required. Install with: brew install gh" and stop.
+2. **Extract owner/repo**: Run `gh repo view --json owner,name -q '.owner.login + "/" + .name'`. Save as `OWNER_REPO`.
+3. **Clean stale worktrees**: Run `git worktree list`. For any entries with paths containing `.claude/worktrees/pr-fix-`, remove them with `git worktree remove --force <path>`.
+
+### Step A2: Discover PRs with review comments
+
+1. Run `gh pr list --search "review:changes_requested" --state open --json number,headRefName,baseRefName,title --limit 10`.
+2. If no results, try a broader search: run `gh pr list --state open --json number,headRefName,baseRefName,title --limit 20`. For each PR, check inline comment count: `gh api repos/{OWNER_REPO}/pulls/<NUMBER>/comments --jq 'length'`. Keep only PRs with comment count > 0.
+3. Deduplicate results by PR number.
+4. Cap the list at MAX_PRS (default 5, or the user-provided override).
+5. If zero PRs have review comments, report "No open PRs with review comments found." and stop.
+
+Save the list as `PR_LIST` with each entry containing: `number`, `headRefName`, `baseRefName`, `title`.
+
+### Step A3: Fetch and group comments per PR
+
+For each PR in `PR_LIST`:
+
+1. Fetch all inline review comments:
+   ```
+   gh api repos/{OWNER_REPO}/pulls/<NUMBER>/comments --paginate
+   ```
+2. For each comment, extract: `id`, `path`, `line`, `original_line`, `body`, `diff_hunk`.
+3. If no comments are found for this PR, remove it from `PR_LIST` and continue.
+4. Group comments that describe the **same underlying issue** (same logic as Fix Mode Step 4).
+5. For each unique issue group, create a summary with issue title, affected files, comment body, and comment IDs.
+
+### Step A4: Display discovery dashboard
+
+Display the full summary:
+
+```
+PR Fix-All Discovery
+=====================
+
+Found <N> open PRs with review comments:
+
+PR #<N1>: <title>
+  Branch: <headRefName> → <baseRefName>
+  Comments: <M> comments in <K> issue groups
+  Issues:
+    1. <issue title> (<file count> files)
+    2. <issue title> (<file count> files)
+
+PR #<N2>: <title>
+  Branch: <headRefName> → <baseRefName>
+  Comments: <M> comments in <K> issue groups
+  Issues:
+    1. <issue title> (<file count> files)
+
+Total: <X> PRs, <Y> issue groups, <Z> comments
+```
+
+If `--dry-run` is active, display this dashboard and stop with message: "Dry run complete. Run `/pr-fix all` without --dry-run to apply fixes."
+
+### Step A5: Process each PR in a worktree
+
+For each PR in `PR_LIST` (sequentially, one at a time):
+
+#### Step A5a: Create worktree
+
+1. Fetch the latest remote state: `git fetch origin <headRefName>`.
+2. Create an isolated worktree:
+   ```
+   git worktree add .claude/worktrees/pr-fix-<NUMBER> origin/<headRefName>
+   ```
+3. If worktree creation fails, log the error, record this PR as `SKIPPED: <reason>`, and continue to the next PR.
+
+Save `.claude/worktrees/pr-fix-<NUMBER>` as `WORKTREE_DIR`.
+
+#### Step A5b: Fix each issue group
+
+For each unique issue group for this PR (maximum 10 groups — if more, warn and skip remaining):
+
+1. **Present**: Show the full comment body and all affected file paths with their diff hunks.
+2. **Read**: Read each affected file from `<WORKTREE_DIR>/<path>` to understand the current code.
+3. **Fix**: Apply the code change that addresses the review comment. All file edits must target files inside `WORKTREE_DIR`.
+4. **Report**: Tell the user what was changed in each file.
+
+#### Step A5c: Regenerate and validate
+
+Same logic as Fix Mode Step 6, but run from `WORKTREE_DIR`.
+
+If any validation fails after 2 retries, record this PR as `FAILED: validation error — <details>` and continue to the next PR (do not push broken code).
+
+#### Step A5d: Commit and push
+
+1. Stage all modified files: `git -C <WORKTREE_DIR> add -A`
+2. Un-stage sensitive files (`.env*`, `credentials.json`, `*.pem`, `*.key`, SSH keys) if any.
+3. Generate a commit message with `fix:` prefix summarizing the review fixes for this PR.
+4. Commit using heredoc:
+   ```
+   git -C <WORKTREE_DIR> commit -m "$(cat <<'EOF'
+   fix: <generated message>
+   EOF
+   )"
+   ```
+5. Do NOT use `--no-verify`. If pre-commit hook fails, fix and retry (up to 2 times). If still failing, record this PR as `FAILED: pre-commit hook — <details>` and continue.
+6. Push: `git -C <WORKTREE_DIR> push`. Do NOT use `--no-verify`.
+
+Save the short commit SHA for this PR.
+
+#### Step A5e: Reply to PR comments
+
+For each issue group that was fixed, reply to ONE comment in the group (the first one) using:
+
+```
+gh api repos/{OWNER_REPO}/pulls/comments/<comment_id>/replies -f body="Fixed in <short-sha>."
+```
+
+#### Step A5f: Record result
+
+Save the result for this PR:
+- **Status**: `FIXED`, `SKIPPED`, or `FAILED`
+- **Commit SHA** (if fixed)
+- **Files modified** (list)
+- **Issues fixed** (count)
+- **Error message** (if skipped or failed)
+
+### Step A6: Cleanup worktrees
+
+For each worktree created during this run:
+```
+git worktree remove .claude/worktrees/pr-fix-<NUMBER> --force
+```
+
+If the `.claude/worktrees/` directory is empty after cleanup, remove it: `rmdir .claude/worktrees/ 2>/dev/null`.
+
+### Step A7: Summary dashboard
+
+Display the consolidated results:
+
+```
+PR Fix-All Summary
+===================
+
+Processed: <N> PRs
+
+✓ FIXED:
+  PR #<N1>: <title>
+    Commit: <sha> — fix: <message>
+    Issues fixed: <K>
+    Files modified: <file list>
+
+  PR #<N2>: <title>
+    Commit: <sha> — fix: <message>
+    Issues fixed: <K>
+    Files modified: <file list>
+
+⊘ SKIPPED:
+  PR #<N3>: <title> — <reason>
+
+✗ FAILED:
+  PR #<N4>: <title> — <reason>
+
+Totals: <X> fixed, <Y> skipped, <Z> failed
+```
+
+If any PRs were fixed, suggest: "Run `/pr-fix all --dry-run` to check for remaining review comments."
+
+If any PRs were skipped or failed, suggest: "Use `/pr-fix <NUMBER>` to handle individual PRs that couldn't be processed."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ python3 generator/generate.py --platform claude
 python3 generator/validate.py
 
 # Lint shell scripts
-shellcheck setup.sh verify.sh scripts/bump-version.sh scripts/run-tests.sh scripts/remote-install.sh scripts/install-hooks.sh platforms/*/install.sh hooks/pre-commit hooks/pre-push
+shellcheck setup.sh verify.sh scripts/bump-version.sh scripts/run-tests.sh scripts/remote-install.sh scripts/install-hooks.sh scripts/run-review-gate.sh platforms/*/install.sh hooks/pre-commit hooks/pre-push
 
 # Install git hooks (run once after cloning)
 bash scripts/install-hooks.sh
@@ -57,10 +57,11 @@ Project-local Claude Code commands in `.claude/commands/` for git workflow autom
 | `/push` | Validate pre-push checks, push to remote |
 | `/ship` | Combined commit + push in one operation |
 | `/ship-pr` | Commit changes to a new branch, push, and open a PR for review |
-| `/pr-fix` | Fetch PR review comments, group by issue, fix, and push. Use `watch` submode with `/loop` for PR babysitting |
+| `/pr-fix` | Fetch PR review comments, group by issue, fix, and push in an isolated worktree. Use `watch` submode with `/loop` for babysitting, `all` submode to fix all open PRs |
 | `/release` | Full release workflow: auto-generate CHANGELOG, bump version, validate, commit, push, and create GitHub Release |
 | `/monitor` | Monitor GitHub Actions CI status, diagnose failures, auto-fix and re-push (up to 3 cycles) |
 | `/docs-sync` | Detect stale documentation after code changes, propose targeted updates for approval |
+| `/full-review-gate` | Comprehensive code review gate: bugs, security, PII/privacy, dependency risks with P0-P3 severity findings and go/no-go release status |
 
 These commands enforce project conventions automatically: conventional commit prefixes (`feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`), sensitive file exclusion, automatic regeneration of platform outputs and checksums when source files change, and pre-commit/pre-push hook compliance (never bypasses hooks).
 

--- a/scripts/run-review-gate.sh
+++ b/scripts/run-review-gate.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+
+# Baseline review gate checks for this repository.
+
+# Note: set -e is intentionally omitted. This script runs multiple checks
+# and tallies pass/fail results. Early exit would prevent subsequent checks.
+set -u
+set -o pipefail
+
+FAILURES=0
+WARNINGS=0
+
+pass() {
+  printf 'PASS: %s\n' "$1"
+}
+
+warn() {
+  printf 'WARN: %s\n' "$1"
+  WARNINGS=$((WARNINGS + 1))
+}
+
+fail() {
+  printf 'FAIL: %s\n' "$1"
+  FAILURES=$((FAILURES + 1))
+}
+
+run_check() {
+  local name="$1"
+  shift
+  printf '\n== %s ==\n' "$name"
+  if "$@"; then
+    pass "$name"
+  else
+    fail "$name"
+  fi
+}
+
+run_negative_rg_check() {
+  local name="$1"
+  local pattern="$2"
+  shift 2
+
+  if ! command -v rg >/dev/null 2>&1; then
+    warn "$name skipped because rg is not installed"
+    return
+  fi
+
+  printf '\n== %s ==\n' "$name"
+  if rg -n --hidden --color=never -P "$pattern" "$@" .; then
+    fail "$name (potential matches found)"
+  else
+    local code=$?
+    if [ "$code" -eq 1 ]; then
+      pass "$name"
+    else
+      fail "$name (rg execution error)"
+    fi
+  fi
+}
+
+printf 'Full Review Gate Baseline\n'
+printf '=========================\n'
+
+run_check "Repository integrity checks" bash verify.sh
+run_check "Test suite" bash scripts/run-tests.sh
+
+if command -v shellcheck >/dev/null 2>&1; then
+  shell_targets=(
+    setup.sh
+    verify.sh
+    scripts/*.sh
+    platforms/*/install.sh
+    hooks/pre-commit
+    hooks/pre-push
+  )
+  run_check "Shell static analysis" shellcheck "${shell_targets[@]}"
+else
+  warn "Shell static analysis skipped because shellcheck is not installed"
+fi
+
+if command -v gitleaks >/dev/null 2>&1; then
+  run_check "Secret scan (gitleaks)" gitleaks detect --no-banner --source .
+else
+  # Fallback heuristic scan for obvious hardcoded secrets.
+  run_negative_rg_check \
+    "Secret scan fallback (regex heuristics)" \
+    '(AKIA[0-9A-Z]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----|(?i)(api[_-]?key|secret|token|password)\s*[:=]\s*[^\s]{8,})' \
+    --glob '!.git/**' \
+    --glob '!docs/**' \
+    --glob '!**/*.md'
+fi
+
+# Heuristic scan for common PII-like literals.
+run_negative_rg_check \
+  "PII scan fallback (regex heuristics)" \
+  '(\b\d{3}-\d{2}-\d{4}\b|\b(?:\d[ -]*?){13,16}\b)' \
+  --glob '!.git/**' \
+  --glob '!docs/**' \
+  --glob '!**/*.md'
+
+if [ -f package.json ]; then
+  if command -v npm >/dev/null 2>&1; then
+    run_check "Dependency vulnerability audit (npm)" npm audit --audit-level=high
+  else
+    warn "Dependency audit skipped because npm is not installed"
+  fi
+fi
+
+if [ -f requirements.txt ] || [ -f requirements-dev.txt ]; then
+  if command -v pip-audit >/dev/null 2>&1; then
+    if [ -f requirements.txt ]; then
+      run_check "Dependency vulnerability audit (pip requirements.txt)" pip-audit -r requirements.txt
+    fi
+    if [ -f requirements-dev.txt ]; then
+      run_check "Dependency vulnerability audit (pip requirements-dev.txt)" pip-audit -r requirements-dev.txt
+    fi
+  else
+    warn "Dependency audit skipped because pip-audit is not installed"
+  fi
+fi
+
+if [ -f go.mod ]; then
+  if command -v govulncheck >/dev/null 2>&1; then
+    run_check "Dependency vulnerability audit (Go)" govulncheck ./...
+  else
+    warn "Dependency audit skipped because govulncheck is not installed"
+  fi
+fi
+
+printf '\nSummary:\n'
+printf '  Failures: %s\n' "$FAILURES"
+printf '  Warnings: %s\n' "$WARNINGS"
+
+if [ "$FAILURES" -gt 0 ]; then
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Migrates the `skills/full-review-gate/` skill into a self-contained Claude Code command at `.claude/commands/full-review-gate.md`
- Review gate now runs in an isolated git worktree, fixes P0/P1 findings, and ships them as a PR targeting the current branch
- Moves `run-review-gate.sh` to `scripts/` alongside existing project scripts
- Updates `/pr-fix` with worktree isolation and new `all` submode for batch PR fixing

## Changes

- `.claude/commands/full-review-gate.md` — new 10-step command: setup worktree → run review → report findings → fix P0/P1 → commit/push → create PR → cleanup
- `scripts/run-review-gate.sh` — baseline check script (verify, tests, shellcheck, secret scan, PII scan, dependency audit) moved from `skills/full-review-gate/scripts/`
- `.claude/commands/pr-fix.md` — enhanced with worktree isolation (no longer modifies working tree) and `all` submode to fix every open PR with review comments
- `CLAUDE.md` — updated command table and shellcheck target list

## Test Plan

- [ ] Run `shellcheck scripts/run-review-gate.sh` — passes
- [ ] Run `bash scripts/run-review-gate.sh` — baseline checks execute
- [ ] Verify `/full-review-gate` appears in Claude Code command list
- [ ] Verify `/pr-fix` worktree isolation works on a test PR
- [ ] Verify `skills/full-review-gate/` directory no longer exists